### PR TITLE
Fix autorestart

### DIFF
--- a/aiotfm/client.py
+++ b/aiotfm/client.py
@@ -77,6 +77,7 @@ class Client:
 		self.auto_restart = auto_restart
 		self.api_tfmid = None
 		self.api_token = None
+		self._restarting = False
 
 		self._channels = []
 
@@ -855,8 +856,13 @@ class Client:
 		:param delay: :class:`int` the delay before restarting. Default is 5 seconds.
 		:param args: arguments to pass to the :meth:`Client.restart` method.
 		:param kwargs: keyword arguments to pass to the :meth:`Client.restart` method."""
+		if self._restarting:
+			return
+
+		self._restarting = True
 		await asyncio.sleep(delay)
 		await self.restart(*args, **kwargs)
+		self._restarting = False
 
 	async def restart(self, keys=None):
 		"""Restarts the client.

--- a/aiotfm/client.py
+++ b/aiotfm/client.py
@@ -874,6 +874,10 @@ class Client:
 
 		self.close()
 
+		# If we don't recreate the connection, we won't be able to connect.
+		self.main = Connection('main', self, self.loop)
+		self.bulle = None
+
 		if keys is not None:
 			self.keys = keys
 		else:

--- a/aiotfm/connection.py
+++ b/aiotfm/connection.py
@@ -40,18 +40,12 @@ class TFMProtocol(asyncio.Protocol):
 			# :desc: Called when a connection has been lost due to an error.
 			# :param connection: :class:`Connection` the connection that has been lost.
 			# :param exception: :class:`Exception` the error which occurred.
-			future = self.client.dispatch('connection_error', self.connection, exc)
-			if future is not None:
-				# This future is a wrapper for _run_event, which returns True if the event
-				# ran successfully, False otherwise.
-				# If it returns False, it already handled the auto_restart.
-				if not asyncio.ensure_future(future):
-					return
+			self.client.dispatch('connection_error', self.connection, exc)
 
-			if self.client.auto_restart:
-				self.client.loop.create_task(self.client.restart_soon())
-			else:
-				self.client.close()
+		if self.client.auto_restart:
+			self.client.loop.create_task(self.client.restart_soon())
+		else:
+			self.client.close()
 
 
 class Connection:


### PR DESCRIPTION
- on_connection_error is not triggering when exc is None (which happens many times, making auto_restart not execute)

This should have been in a fork, but I messed up and instead created a branch :eyes:
I hope that's not a problem LOL