### PR TITLE
Client.getRoomList has been broken for some time.

### DIFF
--- a/aiotfm/room.py
+++ b/aiotfm/room.py
@@ -122,7 +122,6 @@ class RoomEntry:
 		self.mice_mass: int = mice_mass
 		self.map_rotation: list = map_rotation
 
-
 	def __repr__(self):
 		return '<{} {}>'.format(
 			self.__class__.__name__,

--- a/aiotfm/room.py
+++ b/aiotfm/room.py
@@ -91,13 +91,17 @@ class Room:
 class RoomEntry:
 	__slots__ = (
 		'name', 'language', 'country', 'player_count', 'limit',
-		'is_funcorp', 'is_pinned', 'command', 'args'
+		'is_funcorp', 'is_pinned', 'command', 'args', 'is_modified',
+		'shaman_skills', 'consumables', 'adventure', 'collision',
+		'aie', 'map_duration', 'mice_mass', 'map_rotation'
 	)
 
 	def __init__(
 		self, name: str, language: str, country: str, player_count: int,
 		limit: int = 0, is_funcorp: bool = False, is_pinned: bool = False,
-		command: str = '', args: str = ''
+		command: str = '', args: str = '', is_modified: bool = False, shaman_skills: bool = True,
+		consumables: bool = True, adventure: bool = True, collision: bool = False, aie: bool = False,
+		map_duration: int = 100, mice_mass: int = 100, map_rotation: list = []
 	):
 		self.name: str = name
 		self.language: str = language
@@ -108,6 +112,16 @@ class RoomEntry:
 		self.is_pinned: bool = is_pinned
 		self.command: str = command
 		self.args: str = args
+		self.is_modified: bool = is_modified
+		self.shaman_skills: bool = shaman_skills
+		self.consumables: bool = consumables
+		self.adventure: bool = adventure
+		self.collision: bool = collision
+		self.aie: bool = aie
+		self.map_duration: int = map_duration
+		self.mice_mass: int = mice_mass
+		self.map_rotation: list = map_rotation
+
 
 	def __repr__(self):
 		return '<{} {}>'.format(
@@ -192,10 +206,33 @@ class RoomList:
 				player_count = packet.read16()
 				limit = packet.read8()
 				is_funcorp = packet.readBool()
-				packet.readBool()
-				rooms.append(RoomEntry(
-					name, language, country, player_count,
-					limit=limit, is_funcorp=is_funcorp
-				))
+				is_modified = packet.readBool()
+
+				# Read the modified properties
+				if is_modified:
+					shaman_skills = not packet.readBool()
+					consumables = not packet.readBool()
+					adventure = not packet.readBool()
+					collision = packet.readBool()
+					aie = packet.readBool()
+					map_duration = packet.read8()
+					mice_mass = packet.read32()
+					map_rotation = []
+					for i in range(0, packet.read8()):
+						map_rotation.append(packet.read8())
+
+					rooms.append(RoomEntry(
+						name, language, country, player_count,
+						limit=limit, is_funcorp=is_funcorp, is_modified=is_modified,
+						shaman_skills=shaman_skills, consumables=consumables,
+						adventure=adventure, collision=collision, aie=aie,
+						map_duration=map_duration, mice_mass=mice_mass,
+						map_rotation=map_rotation
+					))
+				else:
+					rooms.append(RoomEntry(
+						name, language, country, player_count,
+						limit=limit, is_funcorp=is_funcorp
+					))
 
 		return cls(gamemode, rooms, pinned, gamemodes)

--- a/aiotfm/room.py
+++ b/aiotfm/room.py
@@ -206,7 +206,6 @@ class RoomList:
 				limit = packet.read8()
 				is_funcorp = packet.readBool()
 				is_modified = packet.readBool()
-				print(is_modified)
 
 				kwargs = {
 					"limit": limit,
@@ -230,12 +229,12 @@ class RoomList:
 					# Append the room's specific properties
 					kwargs.update({
 						"is_modified": is_modified,
-				  		"shaman_skills": shaman_skills,
+						"shaman_skills": shaman_skills,
 						"consumables": consumables,
-				   		"adventure": adventure,
+						"adventure": adventure,
 						"collision": collision,
 						"aie": aie,
-				   		"map_duration": map_duration,
+						"map_duration": map_duration,
 						"mice_mass": mice_mass,
 						"map_rotation": map_rotation
 					})

--- a/aiotfm/room.py
+++ b/aiotfm/room.py
@@ -192,7 +192,7 @@ class RoomList:
 				player_count = packet.read16()
 				limit = packet.read8()
 				is_funcorp = packet.readBool()
-
+				packet.readBool()
 				rooms.append(RoomEntry(
 					name, language, country, player_count,
 					limit=limit, is_funcorp=is_funcorp

--- a/aiotfm/room.py
+++ b/aiotfm/room.py
@@ -206,6 +206,12 @@ class RoomList:
 				limit = packet.read8()
 				is_funcorp = packet.readBool()
 				is_modified = packet.readBool()
+				print(is_modified)
+
+				kwargs = {
+					"limit": limit,
+					"is_funcorp": is_funcorp,
+				}
 
 				# Read the modified properties
 				if is_modified:
@@ -217,21 +223,26 @@ class RoomList:
 					map_duration = packet.read8()
 					mice_mass = packet.read32()
 					map_rotation = []
+
 					for i in range(0, packet.read8()):
 						map_rotation.append(packet.read8())
 
-					rooms.append(RoomEntry(
-						name, language, country, player_count,
-						limit=limit, is_funcorp=is_funcorp, is_modified=is_modified,
-						shaman_skills=shaman_skills, consumables=consumables,
-						adventure=adventure, collision=collision, aie=aie,
-						map_duration=map_duration, mice_mass=mice_mass,
-						map_rotation=map_rotation
-					))
-				else:
-					rooms.append(RoomEntry(
-						name, language, country, player_count,
-						limit=limit, is_funcorp=is_funcorp
-					))
+					# Append the room's specific properties
+					kwargs.update({
+						"is_modified": is_modified,
+				  		"shaman_skills": shaman_skills,
+						"consumables": consumables,
+				   		"adventure": adventure,
+						"collision": collision,
+						"aie": aie,
+				   		"map_duration": map_duration,
+						"mice_mass": mice_mass,
+						"map_rotation": map_rotation
+					})
+
+				rooms.append(RoomEntry(
+					name, language, country, player_count,
+					**kwargs
+				))
 
 		return cls(gamemode, rooms, pinned, gamemodes)


### PR DESCRIPTION
I looked over the tfm source code (THANK YOU TOCU) and there is an extra useless Packet.readBoolean().
I've looked over the packet buffers generated by the client and it seems like yes, there is an extra byte at the end that is not read. Hopefully you can also look over it, but this completely fixes it for me!

Tfm source code
```
while(stream.bytesAvailable)
         {
            type = stream.readByte();
            if(type == 0)
            {
               _loc5_ = new class_625(stream.readUTF(),stream.readUTF(),stream.readUTF(),stream.readUnsignedShort(),stream.readUnsignedByte(),stream.readBoolean());
               if(stream.readBoolean()) // THIS BOOLEAN IS EXTRA
               {
                  _loc5_.var_1112 = new class_312().method_1153(stream);
               }
               this.var_1105.push(_loc5_);
            }

```

And the end of a buffer
`\x00\x13*vanilla todo relax\x00\x02\x96\x00\x00` (the last byte isnt covered and that applies to all the rooms)